### PR TITLE
Add onMouseOver and onMouseOut events

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Name | Description | Type | Required
 ---- | ----------- | ---- | --------
 `className` | The dock item's CSS class. | string | no <br><br> default: `undefined`
 `onClick` | The dock item's mouse click event handler. | function | no <br><br> default: `undefined`
+`onMouseOver` | The dock item's mouse over event handler. | function | no <br><br> default: `undefined`
+`onMouseOut` | The dock item's mouse out event handler. | function | no <br><br> default: `undefined`
 
 ## Contributing
 

--- a/lib/dock-item.jsx
+++ b/lib/dock-item.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function(props) {
   return (
-    <div className={props.className} onClick={props.onClick} style={{
+    <div className={props.className} onClick={props.onClick} onMouseOver={props.onMouseOver} onMouseOut={props.onMouseOut} style={{
       width: `${props.width}px`,
       height: `${props.width}px`,
       display: "flex",


### PR DESCRIPTION
I have a use case to add hover state changes on a dock item, and thought others might find this useful as well. This PR passes the `onMouseOver` and `onMouseOut` props to the dock items.

